### PR TITLE
Update gemspec based on `bundle gem` defaults

### DIFF
--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -16,14 +16,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/indieweb/microformats-ruby'
   spec.license       = 'CC0-1.0'
 
-  spec.files         = `git ls-files`.split("\x0").select { |f| f.match(%r{^(bin|lib)/}) }
-
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|vendor)/}) }
   spec.bindir        = 'bin'
-  spec.executables   = ['microformats']
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.post_install_message = 'Prior to version 4.0.0, the microformats gem was named "microformats2."'
 
+  spec.add_development_dependency 'bundler', '~> 1.16', '>= 1.16.1'
   spec.add_development_dependency 'guard-rspec', '~> 4.7', '>= 4.7.3'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rb-fsevent', '~> 0.10.2'

--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|vendor)/}) }
   spec.bindir        = 'bin'
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = ['microformats']
   spec.require_paths = ['lib']
 
   spec.post_install_message = 'Prior to version 4.0.0, the microformats gem was named "microformats2."'


### PR DESCRIPTION
In the course of cleaning up `microformats.gemspec` in #77, I introduced [a change](https://github.com/indieweb/microformats-ruby/pull/77/files#diff-e3aba45ce5da32ccd34a6a6ae8013be5) to the way files are included in the gem:

```rb
spec.files = `git ls-files`.split("\x0").select { |f| f.match(%r{^(bin|lib)/}) }
```

Looking back at it, I don't think that's quite working as I'd intended and this might build the gem with some useful files left out. The change in this PR updates several lines of the gemspec based on Bundler's default when creating a new gem with `bundle gem`.

```rb
spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|vendor)/}) }
```

Apologies for the waffling on this change, but I think this is a more reliable choice.